### PR TITLE
Remove unused constant

### DIFF
--- a/src/shared/services/reservationService.js
+++ b/src/shared/services/reservationService.js
@@ -29,11 +29,6 @@ import { formatDateToString } from '../../utils';
 
 // =================== CONFIGURACIÓN ===================
 
-const DEFAULT_BLOCKED_TABLES = {
-  mediodia: [1, 8, 9, 10],
-  noche: [1, 8, 9, 10]
-};
-
 // =================== FUNCIÓN PRINCIPAL ===================
 
 /**


### PR DESCRIPTION
## Summary
- delete unused `DEFAULT_BLOCKED_TABLES` constant from reservation service
- tidy spacing after removal

## Testing
- `npm run lint` *(fails: 130 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687fd786d36c8331892d777f49ff4a5c