### PR TITLE
Refactor order creation to use Firestore docId

### DIFF
--- a/src/apps/admin/pages/Pedidos/Pedidos.jsx
+++ b/src/apps/admin/pages/Pedidos/Pedidos.jsx
@@ -844,7 +844,7 @@ const Pedidos = ({
   // Manejar creación de pedido
   const handleCreateOrder = async (orderData) => {
     try {
-      const orderId = await OrderService.createOrder(orderData);
+      await OrderService.createOrder(orderData);
 
       setShowOrderModal(false);
       setSelectedTable(null);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -867,8 +867,8 @@ export const addOrder = async (orderData) => {
     };
 
     const docRef = await addDoc(collection(db, 'pedidos'), dataToSave);
-    console.log('✅ Pedido guardado:', { id: docRef.id, estado: dataToSave.estado, mesa: dataToSave.mesa });
-    return docRef.id;
+    console.log('✅ Pedido guardado:', { id: docRef.id, orderId: dataToSave.orderId, mesa: dataToSave.mesa, estado: dataToSave.estado });
+    return { docId: docRef.id, orderId: dataToSave.orderId };
   } catch (error) {
     console.error("Error al agregar pedido:", error);
     throw error;
@@ -879,17 +879,10 @@ export const addOrder = async (orderData) => {
 export const getOrders = async () => {
   try {
     const querySnapshot = await getDocs(collection(db, 'pedidos'));
-    const orders = querySnapshot.docs.map(doc => {
-      const data = doc.data();
-      // Remover el campo 'id' de los datos para evitar conflicto
-      const { id: dataId, ...restData } = data;
-      return {
-        id: doc.id,                    // Document ID real de Firebase (NUNCA sobrescribir)
-        firebaseDocId: doc.id,         // Backup del ID real
-        legacyId: dataId,              // Campo id del documento original (si existe)
-        ...restData                    // Resto de datos sin el campo 'id' conflictivo
-      };
-    });
+    const orders = querySnapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
     return orders;
   } catch (error) {
     console.error("Error al obtener pedidos:", error);

--- a/src/shared/services/OrderService.js
+++ b/src/shared/services/OrderService.js
@@ -4,20 +4,16 @@ import { addOrder, updateOrderStatus, updateTableStatus, updateReservation } fro
  * Crear un nuevo pedido y marcar la mesa como ocupada
  */
 export const createOrder = async (orderData) => {
-  const orderId = `PED-${Date.now()}`;
-  const completeOrder = {
-    ...orderData,
-    id: orderId,
-    orderId,
-    fechaCreacion: new Date(),
-    fechaActualizacion: new Date(),
-    notas: orderData.notas || '',
-  };
-  await addOrder(completeOrder);
+  const cleanData = { ...orderData };
+  delete cleanData.id;
+
+  const { docId } = await addOrder(cleanData);
+
   if (orderData.mesa) {
     await updateTableStatus(orderData.mesa, 'ocupada');
   }
-  return orderId;
+
+  return docId;
 };
 
 /**


### PR DESCRIPTION
## Summary
- remove local id generation from `createOrder`
- return new doc id from `createOrder`
- change `addOrder` to return `{docId, orderId}`
- simplify `getOrders` to return raw data
- adjust admin order page to ignore return value

## Testing
- `npm run lint` *(fails: no-unused-vars, no-constant-condition, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687fe1c5e0888331a39e85acfa47554a