### PR TITLE
Add order id cleanup script

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -346,3 +346,12 @@ ENFOQUE: Flexibilidad operativa total para distribución de mesas.
 *Plan actualizado: 25/1/2025*  
 *Versión: 11.0 - Innovación Operativa*  
 *Estado: Listo para implementar Fase 6 - Sistema de Gestión de Mesas Avanzado*
+## 🗑️ Migración de campo `id` en pedidos
+Para evitar conflictos con el ID nativo de Firestore, se ejecutó un script de una sola vez que elimina el campo `id` en todos los documentos de la colección `pedidos`.
+
+El script está disponible en `scripts/removeOrderIdField.js` y puede ejecutarse con:
+
+```bash
+node scripts/removeOrderIdField.js path/to/serviceAccount.json
+```
+

--- a/scripts/removeOrderIdField.js
+++ b/scripts/removeOrderIdField.js
@@ -1,0 +1,34 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import fs from 'fs';
+
+if (process.argv.length < 3) {
+  console.error('Usage: node removeOrderIdField.js <serviceAccountKey.json>');
+  process.exit(1);
+}
+
+const serviceAccountPath = process.argv[2];
+const serviceAccount = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf8'));
+
+initializeApp({ credential: cert(serviceAccount) });
+const db = getFirestore();
+
+async function run() {
+  const snapshot = await db.collection('pedidos').get();
+  let updated = 0;
+  await Promise.all(
+    snapshot.docs.map(doc => {
+      if (doc.data().id !== undefined) {
+        updated++;
+        return doc.ref.update({ id: FieldValue.delete() });
+      }
+      return Promise.resolve();
+    })
+  );
+  console.log(`Removed id field from ${updated} documents.`);
+}
+
+run().catch(err => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add migration script to remove legacy id field from Firestore orders
- document one-time migration in MIGRATION_PLAN

## Testing
- `npm run lint` *(fails: 124 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fe59d09588331a3e2e7955abaacdf