### PR TITLE
Fix cash register closing logic

### DIFF
--- a/src/apps/admin/pages/Pedidos/Pedidos.jsx
+++ b/src/apps/admin/pages/Pedidos/Pedidos.jsx
@@ -121,15 +121,15 @@ const Pedidos = ({
         firebase: 'en progreso',
         timestamp: new Date().toISOString()
       });
-      
+
       // Guardar arqueo completo en Firebase
       await addCashRegister(arqueoCompleto);
-      
+
       console.log('✅ ARQUEO GUARDADO EXITOSAMENTE EN FIREBASE');
-      
+
       // RESETEO GARANTIZADO: Ejecutar todas las limpiezas
       console.log('🧹 EJECUTANDO RESETEO COMPLETO...');
-      
+
       // 1. Limpiar datos temporales del turno (CRÍTICO)
       closeTurn();
       console.log('✅ Datos temporales del turno limpiados');
@@ -166,20 +166,9 @@ const Pedidos = ({
         timestamp: new Date().toISOString()
       });
       
-      // RESETEO DE EMERGENCIA: Incluso con error, intentar limpiar datos temporales
-      console.log('🚨 EJECUTANDO RESETEO DE EMERGENCIA...');
-      
-      try {
-        closeTurn();
-        setAppliedDiscounts(new Map());
-        console.log('✅ Reseteo de emergencia ejecutado');
-      } catch (emergencyError) {
-        console.error('💥 Error en reseteo de emergencia:', emergencyError);
-      }
-      
       // Mostrar error detallado al usuario
       const errorMessage = error.message || 'Error desconocido al cerrar la caja';
-      showNotification(`❌ Error al cerrar caja: ${errorMessage}`, 'error');
+      showNotification(`❌ Error al cerrar caja: ${errorMessage}. Intenta nuevamente.`, 'error');
       
       // Re-lanzar error para que el modal no se cierre automáticamente
       throw error;


### PR DESCRIPTION
## Summary
- close the turn only after saving the cash register
- remove emergency reset on failure and show a retry message

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fe8555a18833195b0f64562e641a0