### PR TITLE
Add PIN login with Firestore validation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,11 +20,12 @@ import {
   markWaitingAsNotified,
   contactWaitingClient,
   rejectWaitingReservation,
-  auth 
+  getUsuarioByPin,
+  auth
 } from './firebase';
 import { assignTableToNewReservation } from './shared/services/tableManagementService';
 import { UNIFIED_TABLES_LAYOUT as TABLES_LAYOUT, DEFAULT_WALKIN_TABLES } from './utils/tablesLayout';
-import { signInWithEmailAndPassword, signOut } from 'firebase/auth';
+import { signOut } from 'firebase/auth';
 
 import { formatDateToString } from './utils';
 import { db } from './firebase';
@@ -341,30 +342,18 @@ function App() {
     return isValidReservationDate(fecha, turno || 'mediodia', adminOverride);
   };
 
-  const handleLogin = async (username, password) => {
+  const handleLogin = async (pin) => {
     try {
-      let email;
-      let role;
-
-      // Determinar el rol basado en el nombre de usuario
-      if (username === 'admin') {
-        email = import.meta.env.VITE_ADMIN_EMAIL;
-        role = 'admin';
-      } else if (username === 'mozo') {
-        email = import.meta.env.VITE_MOZO_EMAIL;
-        role = 'mozo';
-      } else {
-        return "Usuario no válido";
+      const usuario = await getUsuarioByPin(pin);
+      if (!usuario) {
+        return 'PIN incorrecto';
       }
 
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
-      const user = userCredential.user;
-      
-      setAuthState({ user: username, role });
-      return null; // Login exitoso
+      setAuthState({ usuarioId: usuario.usuarioId, role: usuario.role });
+      return null;
     } catch (error) {
-      console.error("Error de login:", error);
-      return "Usuario o contraseña incorrectos";
+      console.error('Error de login:', error);
+      return 'Error al iniciar sesión';
     }
   };
 

--- a/src/apps/client/pages/Login/LoginView.jsx
+++ b/src/apps/client/pages/Login/LoginView.jsx
@@ -1,27 +1,22 @@
 import React, { useState } from 'react';
-import { User, Lock } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import ClientLayout from '../../layout/ClientLayout';
+import PinLogin from '../../../../shared/components/PinLogin';
 import styles from './LoginView.module.css';
 
 export const LoginView = ({ handleLogin, setScreen, BACKGROUND_IMAGE_URL }) => {
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
     const [error, setError] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const navigate = useNavigate();
 
-    const onSubmit = async (e) => {
-        e.preventDefault(); 
+    const handleSubmit = async (pin) => {
         setIsLoading(true);
         setError('');
-        
         try {
-            const loginError = await handleLogin(username, password);
+            const loginError = await handleLogin(pin);
             if (loginError) {
                 setError(loginError);
             } else {
-                // Login exitoso - navegar a admin
                 navigate('/admin');
             }
         } catch (err) {
@@ -34,37 +29,13 @@ export const LoginView = ({ handleLogin, setScreen, BACKGROUND_IMAGE_URL }) => {
     return (
         <ClientLayout BACKGROUND_IMAGE_URL={BACKGROUND_IMAGE_URL}>
             <h1 className={styles.title}>Iniciar Sesión</h1>
-            <form onSubmit={onSubmit} className={styles.form}>
-                <div className={styles.formGroup}>
-                    <label className={styles.label}><User size={16} className={styles.labelIcon} />Usuario</label>
-                    <input 
-                        type="text" 
-                        value={username}
-                        onChange={(e) => setUsername(e.target.value)}
-                        className={styles.input}
-                        placeholder="Usuario"
-                    />
-                </div>
-                <div className={styles.formGroup}>
-                    <label className={styles.label}><Lock size={16} className={styles.labelIcon} />Contraseña</label>
-                    <input 
-                        type="password" 
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        className={styles.input}
-                        placeholder="********"
-                    />
-                </div>
-
+            <div className={styles.form}>
+                <PinLogin onSubmit={handleSubmit} />
                 {error && <p className={styles.error}>{error}</p>}
-
-                <button type="submit" className={styles.submitButton} disabled={isLoading}>
-                    {isLoading ? 'Iniciando sesión...' : 'Iniciar Sesión'}
-                </button>
                 <button type="button" onClick={() => navigate('/client')} className={styles.backButton}>
                     Volver al inicio
                 </button>
-            </form>
+            </div>
         </ClientLayout>
     );
-}; 
+};

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1897,3 +1897,23 @@ export const deleteTableBlocksForDateTurno = async (fecha, turno) => {
     throw error;
   }
 };
+
+// === Gestión de usuarios ===
+/**
+ * Obtener usuario por PIN
+ * @param {string} pin - PIN numérico del usuario
+ * @returns {Promise<Object|null>} Usuario o null si no existe
+ */
+export const getUsuarioByPin = async (pin) => {
+  try {
+    const usuariosRef = collection(db, 'usuarios');
+    const q = query(usuariosRef, where('pin', '==', pin));
+    const snapshot = await getDocs(q);
+    if (snapshot.empty) return null;
+    const docSnap = snapshot.docs[0];
+    return { id: docSnap.id, ...docSnap.data() };
+  } catch (error) {
+    console.error('Error obteniendo usuario por PIN:', error);
+    throw error;
+  }
+};

--- a/src/router/PrivateRoute.jsx
+++ b/src/router/PrivateRoute.jsx
@@ -7,7 +7,7 @@ import { Navigate } from 'react-router-dom';
  */
 const PrivateRoute = ({ children, auth }) => {
   // Si no hay autenticación, redirigir al login
-  if (!auth || !auth.user) {
+  if (!auth || !(auth.usuarioId || auth.user)) {
     return <Navigate to="/client/login" replace />;
   }
 

--- a/src/shared/components/PinLogin/PinLogin.jsx
+++ b/src/shared/components/PinLogin/PinLogin.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import styles from './PinLogin.module.css';
+import Button from '../ui/Button/Button';
+
+const PinLogin = ({ digits = 4, onSubmit }) => {
+  const [pin, setPin] = useState('');
+
+  const handleNumber = (n) => {
+    if (pin.length < digits) {
+      setPin(pin + n);
+    }
+  };
+
+  const handleBack = () => {
+    setPin(pin.slice(0, -1));
+  };
+
+  const handleEnter = () => {
+    if (pin.length === digits) {
+      onSubmit?.(pin);
+      setPin('');
+    }
+  };
+
+  const renderCircles = () => {
+    return Array.from({ length: digits }).map((_, i) => (
+      <div
+        key={i}
+        className={
+          i < pin.length ? `${styles.circle} ${styles.filled}` : styles.circle
+        }
+      />
+    ));
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.display}>{renderCircles()}</div>
+      <div className={styles.keypad}>
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+          <button key={n} className={styles.key} onClick={() => handleNumber(n)}>
+            {n}
+          </button>
+        ))}
+        <button className={styles.key} onClick={handleBack}>←</button>
+        <button className={styles.key} onClick={() => handleNumber(0)}>0</button>
+        <Button
+          variant="primary"
+          size="sm"
+          className={styles.enter}
+          onClick={handleEnter}
+          disabled={pin.length !== digits}
+        >
+          Ingresar
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PinLogin;

--- a/src/shared/components/PinLogin/PinLogin.module.css
+++ b/src/shared/components/PinLogin/PinLogin.module.css
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.display {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.circle {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 1px solid #4b5563;
+}
+
+.filled {
+  background-color: #22c55e;
+}
+
+.keypad {
+  display: grid;
+  grid-template-columns: repeat(3, 3rem);
+  gap: 0.5rem;
+}
+
+.key {
+  padding: 0.75rem;
+  font-size: 1rem;
+  background-color: rgba(55,65,81,0.5);
+  color: white;
+  border: 1px solid #4b5563;
+  border-radius: 0.5rem;
+}
+
+.enter {
+  grid-column: span 3;
+}

--- a/src/shared/components/PinLogin/index.js
+++ b/src/shared/components/PinLogin/index.js
@@ -1,0 +1,1 @@
+export { default } from './PinLogin';


### PR DESCRIPTION
## Summary
- add helper to get users by PIN in Firebase service
- create `PinLogin` numeric keypad component
- switch login view to use PIN-based flow
- validate pin against `/usuarios` collection and store `usuarioId`
- update `PrivateRoute` to check the new auth field

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887a92daf7c833194989c2530d6dfac