### PR TITLE
Add usuarios rule to Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -52,6 +52,11 @@ service cloud.firestore {
       allow update, delete: if isStaff();
     }
 
+  match /usuarios/{usuarioId} {
+    allow read: if true;         // or `isStaff()` if restricted
+    allow write: if isStaff();   // optional, depending on needs
+  }
+
     // Reglas para lista de espera
     match /lista_espera/{waitingId} {
       // Cualquiera puede crear una reserva en lista de espera


### PR DESCRIPTION
## Summary
- allow `usuarios` read for all users
- restrict `usuarios` write access to staff

## Testing
- `npx firebase --version` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_6887e238e7d483319307df28674f9229